### PR TITLE
Task 4: API query caching

### DIFF
--- a/server/external/rapidapiClient.js
+++ b/server/external/rapidapiClient.js
@@ -6,11 +6,10 @@ const getFromCache = async (requestUrl) => {
 	try {
         const dataString = await getCachedCall(requestUrl);
         if (dataString !== null){
-            const data = JSON.parse(dataString);
-            return data;
+            return JSON.parse(dataString);
         }
         else { 
-            console.log('expected data, but found none');
+            console.log('getFromCache(): expected data, but found none');
             return null;
         }
 	} catch (error) {
@@ -39,7 +38,7 @@ const makeQuery = async (requestUrl, options) => {
     try {
         const keyExists = await checkCache(requestUrl);
         if (keyExists === 1){
-            console.log('key exists in cache, checking now')
+            console.log('makeQuery(): found cached version of API query')
             try {
                 const data = await getFromCache (requestUrl);
                 return data;
@@ -50,13 +49,12 @@ const makeQuery = async (requestUrl, options) => {
         } 
         // data not in cache
         else {
-            console.log('key not in cache, calling API');
+            console.log('makeQuery(): key not in cache, calling API');
             try {
                 // make API call, then cache result for future use
-                console.log('making call')
                 const response = await axios.request(options);
                 const pushstatus = await pushToRedis(requestUrl, response.data);
-                console.log('data cache: ' + pushstatus);
+                console.log('makeQuery(): caching result ' + pushstatus);
                 return response.data;
             } catch (error) {
                 console.log(error);
@@ -73,9 +71,6 @@ const makeQuery = async (requestUrl, options) => {
 // this function makes an API call to the uNoGs unofficial netflix API, provided by rapidapi
 // changing the parameters of the API call is difficult, consult the rapidapi platform
 const getTop10 = async () => {
-
-    console.log('setting up api call')
-
     var options = {
       method: 'GET',
       url: 'https://rapidapi.p.rapidapi.com/aaapi.cgi',
@@ -96,14 +91,10 @@ const getTop10 = async () => {
 
     // retain request URL to query redis or cache response in redis later
     const requestUrl = axios.getUri(options)
-    console.log('built URI of the API request:')
-    console.log(requestUrl);
 
-    console.log('making query now');
     try {
         const data = await makeQuery(requestUrl, options);
         top10 = data.ITEMS.slice(-10);
-        console.log(top10);
         return top10;
     } catch (error) {
         console.log(error);

--- a/server/external/rapidapiClient.js
+++ b/server/external/rapidapiClient.js
@@ -111,5 +111,5 @@ const getTop10 = async () => {
     }
 }
 
-module.exports = {getTop10}
+module.exports = {getTop10, makeQuery}
 

--- a/server/external/rapidapiClient.js
+++ b/server/external/rapidapiClient.js
@@ -1,8 +1,78 @@
 const axios = require("axios").default;
+const { checkCache, getCachedCall, cacheData } = require('../redis.repository');
+
+
+const getFromCache = async (requestUrl) => {
+	try {
+        const dataString = await getCachedCall(requestUrl);
+        if (dataString !== null){
+            const data = JSON.parse(dataString);
+            return data;
+        }
+        else { 
+            console.log('expected data, but found none');
+            return null;
+        }
+	} catch (error) {
+	    console.log(error)
+	    return error
+	}
+}
+
+const pushToRedis = async (requestUrl, data) => {
+  // convert response object into JSON string, cache data in redis
+  const dataString = JSON.stringify(data);
+  return await cacheData(requestUrl, dataString);
+}
+
+
+/**
+ * This function completes a request by checking redis to see if cached response for API call exists.
+ * If it exists, this function returns the data as JSON. 
+ * If it does not exist, this function will make the API call, then cache the result in redis for future use.
+ * @param {String} requestUrl 
+ * @param {Object} options 
+ * @returns {Object} will always return the required data, either from cache or from API call
+ */
+const makeQuery = async (requestUrl, options) => {
+    // check for existence of key
+    try {
+        const keyExists = await checkCache(requestUrl);
+        if (keyExists === 1){
+            console.log('key exists in cache, checking now')
+            try {
+                const data = await getFromCache (requestUrl);
+                return data;
+            } catch (error) {
+                console.log(error);
+                return error;
+            }
+        } 
+        // data not in cache
+        else {
+            console.log('key not in cache, calling API');
+            try {
+                // make API call, then cache result for future use
+                console.log('making call')
+                const response = await axios.request(options);
+                const pushstatus = await pushToRedis(requestUrl, response.data);
+                console.log('data cache: ' + pushstatus);
+                return response.data;
+            } catch (error) {
+                console.log(error);
+                return error
+            }
+        }
+    } catch (error) {
+        console.log(error);
+        return error;
+    }
+}
+
 
 // this function makes an API call to the uNoGs unofficial netflix API, provided by rapidapi
 // changing the parameters of the API call is difficult, consult the rapidapi platform
-const getTop10 = () => {
+const getTop10 = async () => {
 
     console.log('setting up api call')
 
@@ -23,18 +93,22 @@ const getTop10 = () => {
         'x-rapidapi-host': 'unogs-unogs-v1.p.rapidapi.com'
       }
     };
-    
-    console.log('calling')
-    
-    return axios.request(options).then((response) => {
-      console.log('received response, formatting')
-      top10 = response.data.ITEMS.slice(-10)
-      console.log(top10)
-      return top10
-    }).catch(function (error) {
-      console.error(error);
-      return error
-    });
+
+    // retain request URL to query redis or cache response in redis later
+    const requestUrl = axios.getUri(options)
+    console.log('built URI of the API request:')
+    console.log(requestUrl);
+
+    console.log('making query now');
+    try {
+        const data = await makeQuery(requestUrl, options);
+        top10 = data.ITEMS.slice(-10);
+        console.log(top10);
+        return top10;
+    } catch (error) {
+        console.log(error);
+        return error;
+    }
 }
 
 module.exports = {getTop10}

--- a/server/external/rapidapiClient.test.js
+++ b/server/external/rapidapiClient.test.js
@@ -2,10 +2,45 @@ const axios = require('axios')
 const RapidapiClient = require('./rapidapiClient')
 
 jest.mock('axios');
+jest.mock('../redis.repository');
+
+const { checkCache, getCachedCall, cacheData } = require('../redis.repository');
+
+// afterEach(() => {
+//     jest.clearAllMocks();
+// });
+
+describe('API caching tests', () => {
+    test('should fetch from API when URL not in cache', async () => {
+        console.log('testing not in cache');
+        checkCache.mockImplementation(() => 0);
+        cacheData.mockImplementation(() => "OK");
+
+        const resp = {data:"123"};
+        axios.request.mockResolvedValue(resp);
+
+        const result = await RapidapiClient.makeQuery('hello', {hi:'abc'});
+        expect(result).toEqual('123');
+        
+    });
+
+    test('should fetch from redis cache when URL is present', async () => {
+        console.log('testing in cache');
+        checkCache.mockImplementation(() => 1);
+
+        const resp = JSON.stringify({data:'123'});
+        getCachedCall.mockImplementation(() => resp);
+
+        const result = await RapidapiClient.makeQuery('hello', {hi:'abc'});
+        expect(result).toEqual({data: '123'});
+    });
+})
 
 describe('get top 10 tests', () => {
-    
     test('should fetch last 10 movies', () => {
+        console.log('testing get top 10');
+        checkCache.mockImplementation(() => 0);
+        cacheData.mockImplementation(() => "OK");
         const movies = [
             {name: 'movie1'},
             {name: 'movie2'},

--- a/server/external/rapidapiClient.test.js
+++ b/server/external/rapidapiClient.test.js
@@ -6,9 +6,9 @@ jest.mock('../redis.repository');
 
 const { checkCache, getCachedCall, cacheData } = require('../redis.repository');
 
-// afterEach(() => {
-//     jest.clearAllMocks();
-// });
+afterEach(() => {
+    jest.clearAllMocks();
+});
 
 describe('API caching tests', () => {
     test('should fetch from API when URL not in cache', async () => {

--- a/server/redis.repository.js
+++ b/server/redis.repository.js
@@ -128,7 +128,7 @@ const getCachedCall = async (requestUrl) => {
     try {
         return await getAsync(requestUrl);
     } catch (error) {
-        return error
+        return error;
     }
 }
     
@@ -137,7 +137,7 @@ const getCachedCall = async (requestUrl) => {
  * 
  * @param {String} requestUrl literal request URL that corresponds with a cached redis key
  * @param {String} data response data in the form of a JSON string to be used later
- * @returns {Integer} number of fields that were added
+ * @returns {Integer} number of fields that were added, should always be 1
  */
 const cacheData = async (requestUrl, data) => {
     // corresponds to one day
@@ -145,7 +145,7 @@ const cacheData = async (requestUrl, data) => {
     try {
         return await setexAsync(requestUrl, SECONDS, data); 
     } catch (error) {
-        return error
+        return error;
     }
 }
 

--- a/server/redis.repository.js
+++ b/server/redis.repository.js
@@ -95,8 +95,6 @@ const swipingCompleted = (total_swipes, num_guests, num_movies) => {
     }
 }
 
-// BLOCKER: IS THERE A WAY TO DO THIS WITHOUT PASSING ROOM ID AND HOW
-
 const checkCache = async (requestUrl) => {
     try {
         return await existsAsync(requestUrl);


### PR DESCRIPTION
## Description
This PR adds the ability to cache API calls into Redis. 
This means that when API related code is called, Redis will first be checked to see if a cached version of the response data exists. If it does not currently exist, the API call will go through. After this, the response data from the API call will be saved to Redis under the schema {key, value} = {request URL, response JSON string}. This key has a TTL (time-to-live) set at 86400 seconds, corresponding to one day. After one day has passed, the cached request and response data will expire, and another API call will be necessary to add back to the cache. This is necessary to ensure that at least once per day, the application has access to fresh data in case of any updates (new movies being added, movies removed, etc).

This greatly reduces the number of API calls necessary, and drastically improves performance when using the application as well, as any API call that has been made in the last day will be stored and easily accessible from Redis. 

## Changes
- Added redis.repository functions for convenience
- Added functions in rapidapiClient.js to perform get/set operations in redis to read from/write to cache
- Added makeQuery() function that handles caching logic and returns requested data from Redis if possible, and from API otherwise
- Modified getTop10() function to use makeQuery()

## Testing
- Manually testing to ensure no loss of functionality in the application
- Unit tests added to test API caching logic in rapidapiClient.test.js
- Existing unit test for getTop10() modified account for  new caching logic

