### PR TITLE
Feature/sprint4/filtering enhancements

### DIFF
--- a/wewatch-client/src/components/Lobby/Lobby.js
+++ b/wewatch-client/src/components/Lobby/Lobby.js
@@ -2,6 +2,9 @@ import React, { useState, useEffect } from "react";
 import queryString from 'query-string';
 import { Redirect } from "react-router-dom";
 
+import Typography from '@material-ui/core/Typography';
+import Slider from '@material-ui/core/Slider';
+
 import './Lobby.css';
 import Layout from 'views/layout';
 import socket from 'Socket'
@@ -17,10 +20,8 @@ const Lobby = ({location}) => {
     // filters
     const [genreIds, setGenreIds] = useState(null);
     const [genre, setGenre] = useState('all');
-    const [minIrate, setMinIrate] = useState(0);
-    const [maxIrate, setMaxIrate] = useState(10);
-    const [minNrate, setMinNrate] = useState(0);
-    const [maxNrate, setMaxNrate] = useState(5);
+    const [sliderIrate, setSliderIrate] = useState([0, 10]);
+    const [sliderNrate, setSliderNrate] = useState([0, 5]);
 
     const createGenreDropdown = () => {
         let genres = [];
@@ -33,7 +34,7 @@ const Lobby = ({location}) => {
     const onClickStartSession = () => {
         // TODO emit a specific user instead of the first of the user array
         console.log(users[0])
-        const filters = {genre: genre, genreId: genreIds[genre][0], minIrate:minIrate, maxIrate:maxIrate,  minNrate:minNrate, maxNrate:maxNrate};
+        const filters = {genre: genre, genreId: genreIds[genre][0], minIrate:sliderIrate[0], maxIrate:sliderIrate[1],  minNrate:sliderNrate[0], maxNrate:sliderNrate[1]};
         socket.emit('begin', users[0], filters, (error) => {
             if (error) {
                 alert(error);
@@ -141,6 +142,13 @@ const Lobby = ({location}) => {
                 { name === hostName && genreIds !== null?
                     <div className="container">
                     <h1>Filter by:</h1>
+                    { genre !== 'all' || sliderIrate[0] >= 4 || sliderNrate[0] >= 2 ?
+                        <div>
+                        <Typography variant="body1" gutterBottom>
+                            Note: This combination of filters might give you no movies!
+                        </Typography>
+                        </div> : null
+                    }
                     <label>
                         Genre:
                         <select value={genre} onChange={(event) => {setGenre(event.target.value)}}>
@@ -148,28 +156,34 @@ const Lobby = ({location}) => {
                         </select>
                     </label>
                     <div>
-                        <label>
-                            Minimum IMDB rating (out of 10)
-                            <input placeholder="0" type="text" onChange={(event) => setMinIrate(event.target.value)} />
-                        </label>
+                    <Typography id="range-slider" gutterBottom>
+                        IMDB Rating range
+                    </Typography>
+                    <Slider
+                        aria-labelledby="range-slider"
+                        valueLabelDisplay="auto"
+                        marks={true}
+                        step={1}
+                        min={0}
+                        max={10}
+                        value={sliderIrate}
+                        onChange={(event, newValue) => {setSliderIrate(newValue)}}
+                    />
                     </div>
                     <div>
-                        <label>
-                            Maximum IMDB rating (out of 10)
-                            <input placeholder="10" type="text" onChange={(event) => setMaxIrate(event.target.value)} />
-                        </label>
-                    </div>
-                    <div>
-                        <label>
-                            Minimum Netflix rating (out of 5)
-                            <input placeholder="0" type="text" onChange={(event) => setMinNrate(event.target.value)} />
-                        </label>
-                    </div>
-                    <div>
-                        <label>
-                            Maximum Netflix rating (out of 5)
-                            <input placeholder="5" type="text" onChange={(event) => setMaxNrate(event.target.value)} />
-                        </label>
+                    <Typography id="range-slider" gutterBottom>
+                        Netflix Rating range
+                    </Typography>
+                    <Slider
+                        aria-labelledby="range-slider"
+                        valueLabelDisplay="auto"
+                        marks={true}
+                        step={1}
+                        min={0}
+                        max={5}
+                        value={sliderNrate}
+                        onChange={(event, newValue) => {setSliderNrate(newValue)}}
+                    />
                     </div>
                     </div> : null
                 }
@@ -180,5 +194,5 @@ const Lobby = ({location}) => {
     );
   }
 
-  export default Lobby
+  export default Lobby;
   

--- a/wewatch-client/src/components/Lobby/tests/Lobby.test.js
+++ b/wewatch-client/src/components/Lobby/tests/Lobby.test.js
@@ -1,9 +1,52 @@
 import React from 'react';
+import Enzyme, { shallow, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 import ReactDOM from 'react-dom';
+import queryString from 'query-string';
+
 import Lobby from '../Lobby';
 import { BrowserRouter as Router } from "react-router-dom";
+
+Enzyme.configure({ adapter: new Adapter() });
+
+const location_for_host = queryString.stringify({
+    search: {
+      name: 'a_host',
+      roomId: undefined,
+      reset: undefined,
+      oldRoomId: undefined,
+    }
+});
+
+const location_for_user = queryString.stringify({
+    search: {
+      name: 'a_user',
+      roomId: 'test',
+      reset: undefined,
+      oldRoomId: undefined,
+    }
+});
 
 it("renders without crashing", ()=> {
     const div = document.createElement("div");
     ReactDOM.render(<Router><Lobby location="url/to/be/parsed"></Lobby></Router>, div);
 })
+
+
+describe('Render start session button when user is host', () => {
+    const wrapper = shallow(
+        <Lobby location={location_for_host} />
+    );
+    it('Renders button properly when user is host', () => {
+        expect(wrapper.find('button').text()).toBe('Start Session');
+    });
+});
+
+describe('Does not render start session button when user is host', () => {
+    const wrapper = shallow(
+        <Lobby location={location_for_host} />
+    );
+    it('Renders button properly when user is host', () => {
+        expect(wrapper.contains('button')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Description
This PR adds UI enhancements to the filtering component of the Lobby page. This allows hosts to select an IMDB and Netflix rating range using a slider input, as opposed to previous implementations that contained text boxes. This negates the possibility of illegal inputs such as negative numbers, and is also more intuitive to use for the host. Additionally, a note informing the user that the API might return a very small amount of movies, or no movies, is conditionally rendered whenever the combination of filters is no longer optimal. 

Subtasks

- [x] Switch ratings to be stepped slider inputs (discrete values only)
- [x] Add way to notify user when filter combination is likely to result in very small amount of returned data
<img width="1269" alt="Screen Shot 2020-12-05 at 8 02 41 PM" src="https://user-images.githubusercontent.com/26676474/101268749-e2ede280-3734-11eb-9543-c56b7a0e451f.png">

<img width="1246" alt="Screen Shot 2020-12-05 at 8 04 02 PM" src="https://user-images.githubusercontent.com/26676474/101268764-07e25580-3735-11eb-9b40-92268147c7f4.png">

## Tests
- unit tests added for Lobby page, found in tests/Lobby.test.js

## What to look for
- Typograph, Slider components added from material-ui library
- Conditional rendering of note on line 151. Confirm feasibility/limitations of this logic
- Discrete Slider settings should only allow for discrete values, confirm there is no possibility of selecting negative numbers, or continuous numbers (ex. 1.1, 0.1, etc)